### PR TITLE
Updated pods source

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 
 plugin 'cocoapods-whitelist'
 


### PR DESCRIPTION
Github has a download limit, using the Cocoapods CDN is infinitely faster